### PR TITLE
feat: add webpack config js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,61 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+
+const isProd = process.env.NODE_ENV === 'production';
+
+module.exports = {
+  entry: './src/index.jsx',
+  mode: process.env.NODE_ENV,
+  module: {
+    rules: [
+      {
+        test: /\.(js)x?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react'],
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        exclude: /node_modules/,
+        use: [MiniCssExtractPlugin.loader, 'css-loader'],
+      },
+    ],
+  },
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    ...(isProd && { filename: '[name].[contenthash].js' }),
+  },
+  devServer: {
+    static: path.join(__dirname, 'dist'),
+    compress: true,
+    port: 3000,
+  },
+  optimization: {
+    runtimeChunk: {
+      name: 'runtime',
+    },
+    splitChunks: {
+      chunks: 'all',
+      cacheGroups: {
+        framework: {
+          test: /[\\/]node_modules[\\/](react|react-dom)[\\/]/,
+          name: 'framework',
+        },
+        unify: {
+          test: /[\\/]node_modules[\\/](unify-?.*)[\\/]/,
+          name: 'unify',
+        },
+        vendor: {
+          test: /[\\/]node_modules[\\/]((?!(react-?|unify-?)).*)[\\/]/,
+          name: 'vendor',
+        },
+      },
+    },
+  },
+  plugins: [new HtmlWebpackPlugin({ template: './public/index.html' }), new MiniCssExtractPlugin({})],
+};


### PR DESCRIPTION
add webpack.config.js to run in local env, and hopefully meet all of these criteria :
- [X] Support css
- [X] Create multiple bundle output with this criteria:
  - [X] Dependency react, react-dom, react-emotion, and emotion use chunk name `framework.[contenthash].js`
  - [X] All unify dependencies use chunk name `unify.[contenthash].js`
  - [X] The rest node_modules dependencies use chunk name `vendor.[contenthash].js`
  - [X] The runtime code use chunk name `runtime.[contenthash].js`
- [X] All assets should be minified in production build, except in development env
- [X] All chunk name should has `contenthash` in production build, except in development env
